### PR TITLE
Chapter 7(8) review

### DIFF
--- a/chapters/7/snippets/hostpath-pv.yml
+++ b/chapters/7/snippets/hostpath-pv.yml
@@ -9,5 +9,5 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
   hostPath:
-    path: /data
+    path: /mnt
     type: DirectoryOrCreate

--- a/chapters/7/snippets/pod-busybox-rbd.yml
+++ b/chapters/7/snippets/pod-busybox-rbd.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: busybox
+  namespace: default
 spec:
   containers:
     - name: busybox

--- a/chapters/7/snippets/sc-hostpath-pod.yml
+++ b/chapters/7/snippets/sc-hostpath-pod.yml
@@ -14,4 +14,4 @@ spec:
   volumes:
     - name: shared-data
       persistentVolumeClaim:
-        claimName: sc-hostpath-pv
+        claimName: sc-hostpath-pvc


### PR DESCRIPTION
Fixes the following errors:

1. MountVolume.SetUp failed for volume "hostpath-pv" :
mkdir /data: operation not permitted

As explained in https://access.redhat.com/solutions/5518641: "Red Hat CoreOS only allow write access to certain locations such as /mnt, /srv, and /var/mnt. Writing in the
root of the / filesystem is not allowed."

2. Without namespace, pod busybox fails to create in the UI

3. 0/1 nodes are available: persistentvolumeclaim "sc-
hostpath-pv" not found. preemption: 0/1 nodes are
available: 1 Preemption is not helpful for scheduling